### PR TITLE
feat: add more font weights supports

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,8 @@
 ---
-import "@fontsource/ibm-plex-sans-thai";
+import "@fontsource/ibm-plex-sans-thai/400.css";
+import "@fontsource/ibm-plex-sans-thai/500.css";
+import "@fontsource/ibm-plex-sans-thai/600.css";
+import "@fontsource/ibm-plex-sans-thai/700.css";
 
 import Nav from "@/components/Nav.astro";
 import Footer from "@/components/Footer.astro";


### PR DESCRIPTION
## Change made

- [x] Bug fixes
- [x] New features

## Describe what you have done

- Import varies font weights from `@fontsource`

### New Features

- IBM in this site supports 400, 500, 600, 700

### Fix

- font weights didn't support any other than 400
